### PR TITLE
Jwks and dal updates

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,4 +10,5 @@ omit =
     tests/*
 exclude_also = 
     @abstractmethod
-    @raise NotImplementedError
+    raise NotImplementedError
+    pass

--- a/pycommon/authz.py
+++ b/pycommon/authz.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 from datetime import datetime
+from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import boto3
@@ -42,6 +43,9 @@ from pycommon.exceptions import (
 from pycommon.lzw import is_lzw_compressed_format, lzw_uncompress
 
 ALGORITHMS = ["RS256"]
+# used to minimize the number of calls to OAuth issuer for JWKS
+JWKS_CACHE_TTL = 60 * 5  # 5 minutes
+JWKS_CACHE_TIME = None
 
 # Globals needed by this file
 load_dotenv(dotenv_path=".env.local")
@@ -105,6 +109,89 @@ def add_api_access_types(access_types: List[str]):
     _access_types += access_types
 
 
+def get_jwks_for_url(oauth_issuer_base_url: str, fail_open: bool = True) -> dict:
+    """Retrieve the JSON Web Key Set (JWKS) from the OAuth issuer.
+
+    Note that this function is memoized and will cache the result for
+    subsequent calls with the same issuer URL. The cache is invalidated
+    every 5 minutes to reduce stale keys being available.
+
+    We provide a "fail_closed" or "fail_open" mechanism here. If the
+    JWKS cannot be retrieved and the "fail_open" parameter is set to True,
+    the function will return the matching from the cache if available,
+    otherwise it will raise an exception. If "fail_open" is False, the
+    function will raise an exception if the JWKS cannot be retrieved.
+
+    The fail_open is defaulted to True because we assume that an outage of
+    the OAuth issuer should not take down the entire system and likely does
+    not represent some kind of token revocation or similar security action.
+    It would be safer to default to False and that is a call the deploying
+    system should make.
+
+    Args:
+        oauth_issuer_base_url (str): The base URL of the OAuth issuer.
+        fail_open (bool): Whether to fail open (True) or closed (False)
+
+    Returns:
+        dict: The JWKS retrieved from the issuer.
+
+    Raises:
+        ClaimException: If the JWKS cannot be retrieved or is invalid.
+    """
+    jwks = None
+    try:
+        global JWKS_CACHE_TIME
+        # start by getting the cache if it exists
+        jwks = _get_jwks_for_url(oauth_issuer_base_url, fail_open)
+        # if its been too long since we snagged an updated jwks
+        if (
+            JWKS_CACHE_TIME is None
+            or (datetime.now() - JWKS_CACHE_TIME).total_seconds() > JWKS_CACHE_TTL
+        ):
+            _get_jwks_for_url.cache_clear()
+            # this'll update the cache and return the new version
+            jwks = _get_jwks_for_url(oauth_issuer_base_url, fail_open)
+            # restart the cache timer
+            JWKS_CACHE_TIME = datetime.now()
+        return jwks
+    except requests.exceptions.ConnectionError:
+        # if we reach this point, we've tried to get a new JWKS but the
+        # endpoint is unreachable. So we take our fail open/closed logic
+        # into account.
+        if fail_open:
+            if jwks is not None:
+                return jwks
+        raise ClaimException(f"JWKS endpoint unreachable. fail_open = {fail_open}")
+
+
+@lru_cache(maxsize=1)
+def _get_jwks_for_url(oauth_issuer_base_url: str, fail_open: bool) -> dict:
+    """Retrieve the JSON Web Key Set (JWKS) from the OAuth issuer.
+
+    This is the private implementation that is cached and actually
+    retrieves the JWKS.
+
+    Args:
+        kid (str): The key ID to retrieve the JWKS for.
+
+    Returns:
+        dict: The JWKS for the specified key ID.
+    """
+    jwks_url: str = f"{oauth_issuer_base_url}/.well-known/jwks.json"
+
+    try:
+        jwks_response: Response = requests.get(jwks_url)
+        if not jwks_response.ok:
+            raise ClaimException(
+                f"Failed to retrieve JWKS from {jwks_url}, status code: {jwks_response.status_code}"  # noqa: E501
+            )
+        jwks_data: dict = jwks_response.json()
+        return jwks_data
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON response from JWKS: {e}")
+        raise ClaimException("Invalid JWKS response")
+
+
 @required_env_vars("OAUTH_ISSUER_BASE_URL", "OAUTH_AUDIENCE", "ACCOUNTS_DYNAMO_TABLE")
 def get_claims(token: str) -> dict:
     """Retrieve and validate claims from a JSON Web Token (JWT).
@@ -141,20 +228,9 @@ def get_claims(token: str) -> dict:
 
     idp_prefix: str = (os.getenv("IDP_PREFIX") or "").lower()
 
-    jwks_url: str = f"{oauth_issuer_base_url}/.well-known/jwks.json"
-
     # Try to get the jwks here and fail otherwise
-    try:
-        jwks: Response = requests.get(jwks_url)
-        if not jwks.ok:
-            raise ClaimException(
-                f"Failed to retrieve JWKS from {jwks_url}, status code: {jwks.status_code}"  # noqa: E501
-            )
-        jwks_data: dict = jwks.json()
-        header = jwt.get_unverified_header(token)
-    except json.JSONDecodeError as e:
-        print(f"Error decoding JSON response from JWKS: {e}")
-        raise ClaimException("Invalid JWKS response")
+    jwks_data = get_jwks_for_url(oauth_issuer_base_url, fail_open=True)
+    header = jwt.get_unverified_header(token)
 
     # This datastructure is:
     # { "keys": [ {}, {}, ... ] }

--- a/pycommon/dal/__init__.py
+++ b/pycommon/dal/__init__.py
@@ -22,4 +22,5 @@ __all__ = [
     "UserABC",
     "AccountABC",
     "BackendABC",
+    "AdminConfigABC",
 ]

--- a/pycommon/dal/contracts.py
+++ b/pycommon/dal/contracts.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Iterable, Type
+from typing import Any, ClassVar, Iterable, Optional, Type
 
 
 class UserABC(ABC):
@@ -112,8 +112,42 @@ class AccountABC(ABC):
     ) -> AccountABC | None: ...
 
 
+class AdminConfigABC(ABC):
+    provider: ClassVar[Any] = None
+
+    @abstractmethod
+    def __init__(self, **config: Any) -> None:
+        """Provides access to admin configuration tables"""
+        pass
+
+    @abstractmethod
+    def get_config(self, key: str) -> dict | None:
+        """Retrieve a configuration value by key."""
+        pass
+
+    @abstractmethod
+    def set_config(self, key: str, value: Any) -> bool:
+        """Set (overwrite) a configuration value by key."""
+        pass
+
+    @abstractmethod
+    def delete_config(self, key: str) -> bool:
+        """Delete a configuration value by key."""
+        pass
+
+    @abstractmethod
+    def list(self, limit: int = 100, cursor: Optional[str] = None) -> list[str]:
+        """List all configuration keys."""
+        pass
+
+    @abstractmethod
+    def update_config(self, key: str, value: str) -> None:
+        """Update a configuration value by key."""
+        pass
+
+
 # all required classes to fully implement a backend for Amplify
-required = {"User": UserABC, "Account": AccountABC}
+required = {"User": UserABC, "Account": AccountABC, "AdminConfig": AdminConfigABC}
 
 
 class BackendABC(ABC):
@@ -126,6 +160,7 @@ class BackendABC(ABC):
     # abstract "class attributes" (enforced by __init_subclass__)
     User: Type[UserABC]
     Account: Type[AccountABC]
+    AdminConfig: Type[AdminConfigABC]
 
     def __init_subclass__(cls) -> None:
         super().__init_subclass__()

--- a/pycommon/dal/dal.py
+++ b/pycommon/dal/dal.py
@@ -1,14 +1,13 @@
 from enum import Enum, auto
 from typing import Any, Dict, Type
 
-from .contracts import AccountABC, BackendABC, UserABC
+from .contracts import AccountABC, AdminConfigABC, BackendABC, UserABC
 from .errors import DalError
 
 
 class Backend(Enum):
-    MEMORY = auto()
     AWS = auto()
-    # GCP = auto()
+    MEMORY = auto()
     # AZURE = auto()
 
 
@@ -36,3 +35,4 @@ class DAL:
         # expose the bound classes
         self.User: Type[UserABC] = self._backend.User
         self.Account: Type[AccountABC] = self._backend.Account
+        self.AdminConfig: Type[AdminConfigABC] = self._backend.AdminConfig

--- a/pycommon/dal/providers/aws/AwsAccount.py
+++ b/pycommon/dal/providers/aws/AwsAccount.py
@@ -47,7 +47,7 @@ class AwsAccount(AccountABC):
 
     # TODO: This should use a generic getter method that supports arbitrary
     # value stores (e.g., kv store, env, etc)
-    user_table_name: ClassVar[str] = os.getenv("COGNITO_USERS_TABLE")
+    account_table_name: ClassVar[str] = os.getenv("ACCOUNTS_DYNAMO_TABLE")
 
     def __init__(
         self,
@@ -104,7 +104,7 @@ class AwsAccount(AccountABC):
 
     @classmethod
     def _user_table(cls):
-        return cls.provider.get_table(cls.user_table_name)
+        return cls.provider.get_table(cls.account_table_name)
 
     def save(self) -> None:
         """

--- a/pycommon/dal/providers/aws/AwsAdminConfig.py
+++ b/pycommon/dal/providers/aws/AwsAdminConfig.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+from typing import Any, ClassVar, Dict, Optional
+
+from pycommon.dal.contracts import AdminConfigABC
+from pycommon.dal.providers.aws import AwsProvider
+from pycommon.dal.providers.aws.helpers import map_aws_error
+
+
+class AwsAdminConfig(AdminConfigABC):
+    """AWS-specific admin configuration implementation."""
+
+    provider: ClassVar[AwsProvider]
+    config_table: ClassVar[str] = os.getenv("AMPLIFY_ADMIN_DYNAMODB_TABLE")
+
+    def __init__(self, **config: dict) -> None:
+        """Provides access to admin configuration tables"""
+        # Currently, there are no specific configurations needed.
+        pass
+
+    @classmethod
+    def _table(cls):
+        return cls.provider.get_table(cls.config_table)
+
+    @classmethod
+    def get_config(cls, key: str) -> dict | None:
+        """Retrieve a configuration value by key.
+
+        Because the config entries are not consistent, this function
+        relies on the record including a 'data' field that is a dict.
+        It is this dict that will be returned because the underlying
+        structure is not guaranteed.
+
+        """
+        try:
+            table = cls._table()
+            resp = table.get_item(Key={"config_id": key})
+            item = resp.get("Item")
+            if not item:
+                return None
+            data = item.get("data")
+            if not data:
+                return None
+            return data
+        except Exception as e:
+            raise map_aws_error(e)
+
+    def set_config(self, key: str, value: Any) -> bool:
+        """Set (overwrite) a configuration value by key."""
+        raise NotImplementedError("set_config is not implemented yet")
+
+    def delete_config(self, key: str) -> bool:
+        """Delete a configuration value by key."""
+        raise NotImplementedError("delete_config is not implemented yet")
+
+    @classmethod
+    def list(
+        cls, limit: int = 100, cursor: Optional[str] = None
+    ) -> tuple[list[str], Optional[str]]:
+        """List all configuration keys."""
+        ret: list[str] = []
+        try:
+            table = cls._table()
+            kwargs: Dict[str, Any] = {"Limit": limit}
+            if cursor:
+                kwargs["ExclusiveStartKey"] = {"config_id": cursor}
+
+            resp = table.scan(ProjectionExpression="config_id")
+            for item in resp.get("Items", []):
+                ret.append(item["config_id"])
+            return ret, resp.get("LastEvaluatedKey")
+        except Exception as e:
+            raise map_aws_error(e)
+
+    def update_config(self, key: str, value: str) -> None:
+        """Update a configuration value by key."""
+        raise NotImplementedError("update_config is not implemented yet")

--- a/pycommon/dal/providers/aws/AwsUser.py
+++ b/pycommon/dal/providers/aws/AwsUser.py
@@ -12,7 +12,7 @@ from pycommon.dal.providers.aws.helpers import map_aws_error, nowstr
 
 class AwsUser(UserABC):
     provider: ClassVar[AwsProvider]
-    user_table_name: ClassVar[str] = os.getenv("ACCOUNTS_DYNAMO_TABLE")
+    user_table_name: ClassVar[str] = os.getenv("COGNITO_USERS_TABLE")
 
     def __init__(
         self,

--- a/pycommon/dal/providers/aws/__init__.py
+++ b/pycommon/dal/providers/aws/__init__.py
@@ -1,6 +1,7 @@
 # isort: off
 from .AwsProvider import AwsProvider
 from .AwsAccount import AwsAccount
+from .AwsAdminConfig import AwsAdminConfig
 from .AwsUser import AwsUser
 from .aws import AwsBackend
 
@@ -10,4 +11,5 @@ __all__ = [
     "AwsAccount",
     "AwsUser",
     "AwsBackend",
+    "AwsAdminConfig",
 ]

--- a/pycommon/dal/providers/aws/aws.py
+++ b/pycommon/dal/providers/aws/aws.py
@@ -3,7 +3,7 @@ from typing import Any, Dict
 
 import boto3
 
-from pycommon.dal.providers.aws import AwsAccount, AwsProvider, AwsUser
+from pycommon.dal.providers.aws import AwsAccount, AwsAdminConfig, AwsProvider, AwsUser
 
 from ...contracts import BackendABC
 from ...dal import Backend, register_backend
@@ -13,9 +13,10 @@ class AwsBackend(BackendABC):
 
     User = AwsUser
     Account = AwsAccount
+    AdminConfig = AwsAdminConfig
 
     def __init__(self, **config: Any) -> None:
-        boto3_kwargs: Dict[str, Any] = config.get("boto3_kwargs", {}) or {}
+        boto3_kwargs: Dict[str, Any] = config.get("boto3_kwargs", {})
 
         dynamodb = boto3.resource("dynamodb", **boto3_kwargs)
 
@@ -24,6 +25,7 @@ class AwsBackend(BackendABC):
         # Bind provider context to the AR classes
         self.User.provider = provider
         self.Account.provider = provider
+        self.AdminConfig.provider = provider
 
 
 # Register at import time

--- a/tests/test_AwsAccounts.py
+++ b/tests/test_AwsAccounts.py
@@ -57,13 +57,13 @@ def test_repr():
 def test_user_table(monkeypatch):
     provider = setup_provider(monkeypatch)
     table = AwsAccount._user_table()
-    assert provider.called == [AwsAccount.user_table_name]
-    assert table is provider.tables[AwsAccount.user_table_name]
+    assert provider.called == [AwsAccount.account_table_name]
+    assert table is provider.tables[AwsAccount.account_table_name]
 
 
 def test_save_adds_account(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     # Simulate no accounts yet
     table.get_item.return_value = {"Item": {"user": "u1", "accounts": []}}
     acct = make_account()
@@ -76,7 +76,7 @@ def test_save_adds_account(monkeypatch):
 
 def test_save_updates_account(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     # Simulate existing account with same id
     table.get_item.return_value = {
         "Item": {
@@ -101,7 +101,7 @@ def test_save_updates_account(monkeypatch):
 
 def test_save_creates_new_item(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     # Simulate no Item returned
     table.get_item.return_value = {}
     acct = make_account()
@@ -112,7 +112,7 @@ def test_save_creates_new_item(monkeypatch):
 
 def test_delete_removes_account(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     # Simulate existing accounts
     table.get_item.return_value = {
         "Item": {
@@ -144,7 +144,7 @@ def test_delete_removes_account(monkeypatch):
 
 def test_delete_no_item(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     # Simulate no existing accounts
     table.get_item.return_value = {}
     acct = make_account(id="u1:acct1")
@@ -164,7 +164,7 @@ def test_get_all_for_user_calls_get_account_by_id_for_user(monkeypatch):
 
 def test_get_account_by_id_for_user_no_item(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     table.get_item.return_value = {"Item": None}
     result = AwsAccount.get_account_by_id_for_user("u1", None)
     assert result == []
@@ -172,7 +172,7 @@ def test_get_account_by_id_for_user_no_item(monkeypatch):
 
 def test_get_account_by_id_for_user_no_accounts(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     table.get_item.return_value = {"Item": {"user": "u1", "accounts": []}}
     result = AwsAccount.get_account_by_id_for_user("u1", None)
     assert result == []
@@ -180,7 +180,7 @@ def test_get_account_by_id_for_user_no_accounts(monkeypatch):
 
 def test_get_account_by_id_for_user_found(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     table.get_item.return_value = {
         "Item": {
             "user": "u1",
@@ -210,7 +210,7 @@ def test_get_account_by_id_for_user_found(monkeypatch):
 
 def test_get_account_by_id_for_user_all(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     table.get_item.return_value = {
         "Item": {
             "user": "u1",
@@ -237,7 +237,7 @@ def test_get_account_by_id_for_user_all(monkeypatch):
 
 def test_get_account_has_decimal_rate(monkeypatch):
     provider = setup_provider(monkeypatch)
-    table = provider.get_table(AwsAccount.user_table_name)
+    table = provider.get_table(AwsAccount.account_table_name)
     table.get_item.return_value = {
         "Item": {
             "user": "u1",

--- a/tests/test_AwsAdminConfig.py
+++ b/tests/test_AwsAdminConfig.py
@@ -1,0 +1,88 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from pycommon.dal.providers.aws import AwsAdminConfig
+
+
+def test_get_config_returns_value(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    dummy_table.get_item.return_value = {"Item": {"data": {"bar": 1}}}
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    result = AwsAdminConfig.get_config("foo")
+    assert result == {"bar": 1}
+    dummy_table.get_item.assert_called_once()
+
+
+def test_get_config_returns_none(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    dummy_table.get_item.return_value = {"Item": None}
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    result = AwsAdminConfig.get_config("foo")
+    assert result is None
+
+
+def test_get_config_data_returns_none(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    dummy_table.get_item.return_value = {"Item": {"data": {}}}
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    result = AwsAdminConfig.get_config("foo")
+    assert result is None
+
+
+def test_get_config_raises_exception(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    dummy_table.get_item.return_value = {"Item": {"data": {}}}
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    dummy_table.get_item.side_effect = Exception("Dynamo error")
+    with pytest.raises(Exception, match="Dynamo error"):
+        AwsAdminConfig.get_config("foo")
+
+
+def test_list_fail_with_key_error(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    dummy_table.scan.return_value = {
+        "Items": [{"key": "foo"}, {"key": "bar"}],
+        "LastEvaluatedKey": None,
+    }
+    with pytest.raises(KeyError):
+        AwsAdminConfig.list()
+
+
+def test_list_success(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    dummy_table.scan.return_value = {
+        "Items": [{"config_id": "foo"}, {"config_id": "bar"}],
+        "LastEvaluatedKey": None,
+    }
+    keys, cursor = AwsAdminConfig.list()
+    assert keys == ["foo", "bar"]
+    assert cursor is None
+
+
+def test_list_with_cursor(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    dummy_table.scan.return_value = {
+        "Items": [{"config_id": "foo"}, {"config_id": "bar"}],
+        "LastEvaluatedKey": {"config_id": "bar"},
+    }
+    keys, cursor = AwsAdminConfig.list(cursor="foo")
+    assert keys == ["foo", "bar"]
+    assert cursor == {"config_id": "bar"}

--- a/tests/test_DAL.py
+++ b/tests/test_DAL.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 import pytest
 
-from pycommon.dal.contracts import AccountABC, BackendABC, UserABC
+from pycommon.dal.contracts import AccountABC, AdminConfigABC, BackendABC, UserABC
 from pycommon.dal.dal import _REGISTRY, DAL, Backend, DalError, register_backend
 
 
@@ -14,13 +14,19 @@ class DummyAccount(AccountABC):
     pass
 
 
+class DummyAdminConfig(AdminConfigABC):
+    pass
+
+
 class DummyBackend(BackendABC):
     User = DummyUser
     Account = DummyAccount
+    AdminConfig = DummyAdminConfig
 
     def __init__(self, **config):
         self.User = DummyUser
         self.Account = DummyAccount
+        self.AdminConfig = DummyAdminConfig
 
 
 def test_register_backend_and_dal_instantiation():
@@ -48,11 +54,13 @@ def test_dal_passes_config_to_backend():
     class ConfigBackend(BackendABC):
         User = DummyUser
         Account = DummyAccount
+        AdminConfig = DummyAdminConfig
 
         def __init__(self, **config):
             self.config = config
             self.User = DummyUser
             self.Account = DummyAccount
+            self.AdminConfig = DummyAdminConfig
 
     register_backend(Backend.AWS, ConfigBackend)
     dal = DAL(Backend.AWS, foo="bar")

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -1,20 +1,24 @@
 import json
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import boto3
 import pytest
+import requests
 from jose import ExpiredSignatureError, JWTError
 from jose.exceptions import JWTClaimsError
 from jsonschema.exceptions import ValidationError
 
 from pycommon.authz import (
     _determine_api_user,
+    _get_jwks_for_url,
     _parse_and_validate,
     _parse_token,
     _validate_data,
     add_api_access_types,
     api_claims,
     get_claims,
+    get_jwks_for_url,
     is_rate_limited,
     set_permission_checker,
     set_validate_rules,
@@ -59,6 +63,11 @@ def always_allow_permission_checker(user, type, op, data):
 
 
 always_allow_permission_checker(None, None, None, None)
+
+
+@pytest.fixture(autouse=True)
+def clear_jwks_cache():
+    _get_jwks_for_url.cache_clear()
 
 
 @patch("pycommon.authz.requests.get")
@@ -1892,3 +1901,52 @@ def test_validate_data_with_invalid_compressed_data():
         _validate_data(
             "/compressed", "test", {"data": invalid_compressed}, False, validator_rules
         )
+
+
+def test_get_jwks_with_connection_exception():
+    """Test get_jwks handling a connection error."""
+    with patch("pycommon.authz.requests.get") as mock_get:
+        mock_get.side_effect = requests.exceptions.ConnectionError("Unable to connect")
+        with pytest.raises(
+            ClaimException, match="JWKS endpoint unreachable. fail_open = True"
+        ):
+            get_jwks_for_url("http://invalid-url.com/.well-known/jwks.json")
+
+
+def test_get_jwks_with_connection_exception_fail_closed():
+    """Test get_jwks handling a connection error with fail_open=False."""
+    with patch("pycommon.authz.requests.get") as mock_get:
+        mock_get.side_effect = requests.exceptions.ConnectionError("Unable to connect")
+        with pytest.raises(
+            ClaimException, match="JWKS endpoint unreachable. fail_open = False"
+        ):
+            get_jwks_for_url(
+                "http://invalid-url.com/.well-known/jwks.json", fail_open=False
+            )
+
+
+def test_get_jwks_with_connection_exception_fail_open_with_cache():
+    """Test get_jwks handling a connection error with fail_open=True and cache."""
+    # first call the function and mock success response so jwks is not None
+    # then mock requests.get to fail on the second call
+    with patch("pycommon.authz.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(
+            ok=True,
+            json=MagicMock(
+                return_value={"keys": [{"kid": "cached_kid", "key": "cached_key"}]}
+            ),
+        )
+        # First call to populate the cache
+        jwks = get_jwks_for_url("http://valid-url.com/.well-known/jwks.json")
+        assert jwks is not None
+
+        with patch(
+            "pycommon.authz.JWKS_CACHE_TIME", datetime.now() + timedelta(minutes=-10)
+        ):
+            # Now mock a connection error for the second call
+            mock_get.side_effect = requests.exceptions.ConnectionError(
+                "Unable to connect"
+            )
+            # Second call should return cached JWKS without raising an exception
+            cached_jwks = get_jwks_for_url("http://valid-url.com/.well-known/jwks.json")
+            assert cached_jwks == jwks  # Should return the cached value


### PR DESCRIPTION
This change primarily adjusts the JWKS code that lives in validated decorator. 

It pull the code out that grabs the JWKS key and does two things:
1. memoizes the function so it can reduce the number of calls to Okta
2. Makes getting those jwks available for other functions (e.g., creating accounts)

The other changes are primarily DAL updates and fixes - which are not yet used anywhere and safe for updates.