### PR TITLE
Adjust AwsUser object save() to allow update_item

### DIFF
--- a/pycommon/dal/providers/aws/AwsUser.py
+++ b/pycommon/dal/providers/aws/AwsUser.py
@@ -272,13 +272,44 @@ class AwsUser(UserABC):
                        AWS error is raised.
         """
         try:
-            data: dict = self._create_non_null_dynamodb_dict()
-            data["updated_at"] = nowstr()
-            kwargs: dict = {"Item": data}
+            table = self._user_table()
+            data = self._create_non_null_dynamodb_dict()
+            kwargs = {"Item": data}
             if not allow_overwrite:
                 kwargs["ConditionExpression"] = "attribute_not_exists(user_id)"
-            table = self._user_table()
-            table.put_item(**kwargs)
+
+            resp = table.get_item(Key={"user_id": self.user_id})
+            if not resp.get("Item"):
+                data["updated_at"] = nowstr()
+                table.put_item(**kwargs)
+            else:
+                # remove any keys that don't need updated
+                keys_to_delete = []
+                for k, v in data.items():
+                    if resp["Item"].get(k) == v:
+                        keys_to_delete.append(k)
+
+                for k in keys_to_delete:
+                    del data[k]
+
+                if not data:
+                    return
+
+                data["updated_at"] = nowstr()
+                update_expr = "SET " + ", ".join(
+                    f"#{k}=:{k}" for k in data.keys() if k != "user_id"
+                )
+                expr_attr_names = {f"#{k}": k for k in data.keys() if k != "user_id"}
+                expr_attr_values = {
+                    f":{k}": v for k, v in data.items() if k != "user_id"
+                }
+
+                table.update_item(
+                    Key={"user_id": self.user_id},
+                    UpdateExpression=update_expr,
+                    ExpressionAttributeNames=expr_attr_names,
+                    ExpressionAttributeValues=expr_attr_values,
+                )
         except Exception as e:
             raise map_aws_error(e)
 

--- a/tests/test_AwsUser.py
+++ b/tests/test_AwsUser.py
@@ -89,6 +89,8 @@ def test_create_non_null_dynamodb_dict():
 def test_save_calls_put_item(monkeypatch):
     user = make_user()
     mock_table = MagicMock()
+    mock_table.get_item.return_value = {}
+    mock_table.put_item.return_value = {}
     monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
     monkeypatch.setattr("pycommon.dal.providers.aws.helpers.nowstr", lambda: "now")
     user.save()
@@ -98,6 +100,8 @@ def test_save_calls_put_item(monkeypatch):
 def test_save_condition_expression(monkeypatch):
     user = make_user()
     mock_table = MagicMock()
+    mock_table.get_item.return_value = {}
+    mock_table.put_item.return_value = {}
     monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
     monkeypatch.setattr("pycommon.dal.providers.aws.helpers.nowstr", lambda: "now")
     user.save(allow_overwrite=False)
@@ -355,6 +359,8 @@ def test_create_non_null_dynamodb_dict_excludes_none_fields():
 def test_save_sets_updated_at(monkeypatch):
     user = make_user()
     mock_table = MagicMock()
+    mock_table.get_item.return_value = {}
+    mock_table.put_item.return_value = {}
     monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
     with patch(
         "pycommon.dal.providers.aws.AwsUser.nowstr", return_value="2024-06-01T12:00:00Z"
@@ -362,6 +368,45 @@ def test_save_sets_updated_at(monkeypatch):
         user.save()
         args, kwargs = mock_table.put_item.call_args
         assert kwargs["Item"]["updated_at"] == "2024-06-01T12:00:00Z"
+
+
+def test_save_existing_sets_updated_at(monkeypatch):
+    user = make_user()
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {"user_id": "u1", "email": "test@example.com"}
+    }
+    mock_table.update_item.return_value = {
+        "ExpressionAttributeValues": {"updated_at": "2024-06-01T12:00:00Z"}
+    }
+    monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
+    with patch(
+        "pycommon.dal.providers.aws.AwsUser.nowstr", return_value="2024-06-01T12:00:00Z"
+    ):
+        user.save()
+        args, kwargs = mock_table.update_item.call_args
+        assert (
+            kwargs["ExpressionAttributeValues"][":updated_at"] == "2024-06-01T12:00:00Z"
+        )
+
+
+def test_save_existing_empty_data(monkeypatch):
+    user = make_user()
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {"user_id": "u1", "email": "test@example.com"}
+    }
+    mock_table.update_item.return_value = {
+        "ExpressionAttributeValues": {"updated_at": "2024-06-01T12:00:00Z"}
+    }
+    user._create_non_null_dynamodb_dict = MagicMock(return_value={})
+    monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
+    with patch(
+        "pycommon.dal.providers.aws.AwsUser.nowstr", return_value="2024-06-01T12:00:00Z"
+    ):
+        user.save()
+        assert not mock_table.update_item.called
+        assert not mock_table.put_item.called
 
 
 def test_save_raises_mapped_exception(monkeypatch):


### PR DESCRIPTION
The initial implementation of save() only allowed for put_item, which seemed reasonable at the time to overwrite the entire object. However, this will also crush attributes that may have been added after the fact. It also may introduce strange behavior under certain special circumstances.
So this update uses `update` semantics (boto3) if the item exists otherwise put semantics to create a new object.