### PR TITLE
Fix a bug when pulling unserializable values from dynamodb

### DIFF
--- a/pycommon/dal/providers/aws/AwsUser.py
+++ b/pycommon/dal/providers/aws/AwsUser.py
@@ -208,13 +208,14 @@ class AwsUser(UserABC):
         return self._cust_saml_groups
 
     @cust_saml_groups.setter
-    def cust_saml_groups(self, value: list[str] | None) -> None:
+    def cust_saml_groups(self, value: list[str] | str | None) -> None:
         """
         Sets the custom SAML groups for the user.
 
         Args:
-            value (list[str] | None): A list of group names as strings, or None
-                                      to clear the groups.
+            value (list[str] | str | None): A list of group names as strings, or None
+                                      to clear the groups. Some legacy Dynamodb records
+                                      included a string that was not deserializable JSON.
 
         Raises:
             TypeError: If value is not a list of strings.
@@ -222,12 +223,20 @@ class AwsUser(UserABC):
         Side Effects:
             Updates the internal _cust_saml_groups attribute with a JSON-encoded
             list (stringified) of group names or None.
-        """
+        """  # noqa: E501
         if value is None:
             self._cust_saml_groups = None
             return
-        if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
-            raise TypeError("cust_saml_groups must be a list of strings")
+        if isinstance(value, str):
+            value = [
+                str(item).strip("'\" ")  # treat as string, remove quotes and spaces
+                for item in value.strip("[]").split(",")
+                if item.strip() and item is not None
+            ]
+        elif isinstance(value, list):
+            value = [str(x) for x in value if x is not None]
+        else:
+            raise TypeError("cust_saml_groups must be a list of strings or a string")
         self._cust_saml_groups = json.dumps(value)
 
     def _get_values_as_dict(self) -> dict:

--- a/tests/test_AwsUser.py
+++ b/tests/test_AwsUser.py
@@ -53,8 +53,17 @@ def test_cust_saml_groups_getter_and_setter():
     assert json.loads(user.cust_saml_groups) == ["saml1", "saml2"]
     user.cust_saml_groups = None
     assert user.cust_saml_groups is None
+
+    user.cust_saml_groups = [1, 2]
+    assert json.loads(user.cust_saml_groups) == ["1", "2"]
+
+
+def test_cust_saml_bad_type():
+    user = make_user()
     with pytest.raises(TypeError):
-        user.cust_saml_groups = [1, 2]
+        user.cust_saml_groups = 123
+    with pytest.raises(TypeError):
+        user.cust_saml_groups = {"a": 1}
 
 
 def test_updated_at_getter():
@@ -233,12 +242,26 @@ def test_cust_vu_groups_setter_type_error():
 
 def test_cust_saml_groups_setter_type_error():
     user = make_user()
-    with pytest.raises(TypeError):
-        user.cust_saml_groups = "not a list"
-    with pytest.raises(TypeError):
-        user.cust_saml_groups = [1, "valid", {}]
-    with pytest.raises(TypeError):
-        user.cust_saml_groups = [None, "valid"]
+    user.cust_saml_groups = [None, "valid"]
+    assert user.cust_saml_groups == '["valid"]'
+
+    user.cust_saml_groups = [1, "valid", {}]
+    assert user.cust_saml_groups == '["1", "valid", "{}"]'
+
+    # assert does not raise
+    user.cust_saml_groups = "saml1, saml2"
+    assert user.cust_saml_groups == '["saml1", "saml2"]'
+    user.cust_saml_groups = '["saml3", "saml4"]'
+    assert user.cust_saml_groups == '["saml3", "saml4"]'
+
+    user.cust_saml_groups = '"saml1", "saml2"'
+    assert user.cust_saml_groups == '["saml1", "saml2"]'
+
+    user.cust_saml_groups = "'saml1', 'saml2'"
+    assert user.cust_saml_groups == '["saml1", "saml2"]'
+
+    user.cust_saml_groups = "[group1, group2, group3]"
+    assert user.cust_saml_groups == '["group1", "group2", "group3"]'
 
 
 def test_get_by_user_id_not_found(monkeypatch):


### PR DESCRIPTION
some of the SAML groups stored in dynamodb are not serializable. While we write all new values correctly, we need to pull the old values correctly and fix them. This patch adds some functionality for that.