### PR TITLE
Add REMOVE semantics to save() on User

### DIFF
--- a/pycommon/dal/providers/aws/AwsUser.py
+++ b/pycommon/dal/providers/aws/AwsUser.py
@@ -280,9 +280,14 @@ class AwsUser(UserABC):
             Exception: If the DynamoDB operation fails, an appropriate mapped
                        AWS error is raised.
         """
+        # because the dynamodb table has keys like "custom:saml_groups",
+        # we need to alias them for the update expression because boto3
+        # doesn't like special characters in the expression attribute names.
+        key_alias = lambda k: f"{k.replace(':','_')}"  # noqa: E731
+
         try:
             table = self._user_table()
-            data = self._create_non_null_dynamodb_dict()
+            data = self._get_values_as_dict()
             kwargs = {"Item": data}
             if not allow_overwrite:
                 kwargs["ConditionExpression"] = "attribute_not_exists(user_id)"
@@ -294,32 +299,39 @@ class AwsUser(UserABC):
             else:
                 # remove any keys that don't need updated
                 keys_to_delete = []
+                attrs_to_delete = []
+                data["updated_at"] = nowstr()
+
+                # remove any keys which match both sides
                 for k, v in data.items():
-                    if resp["Item"].get(k) == v:
+                    if data.get(k) is None and resp["Item"].get(k) is not None:
+                        attrs_to_delete.append(k)
+                    elif resp["Item"].get(k) == v:
                         keys_to_delete.append(k)
 
                 for k in keys_to_delete:
                     del data[k]
 
-                if not data:
+                if not data or data.keys() == {"updated_at"}:
                     return
 
-                # because the dynamodb table has keys like "custom:saml_groups",
-                # we need to alias them for the update expression because boto3
-                # doesn't like special characters in the expression attribute names.
-                key_alias = lambda k: f"{k.replace(':','_')}"  # noqa: E731
-
-                data["updated_at"] = nowstr()
                 update_expr = "SET " + ", ".join(
                     f"#{key_alias(k)}=:{key_alias(k)}"
                     for k in data.keys()
-                    if k != "user_id"
+                    if k != "user_id" and k not in attrs_to_delete
                 )
+                if attrs_to_delete:
+                    update_expr += " REMOVE " + ", ".join(
+                        [f"#{key_alias(k)}" for k in attrs_to_delete]
+                    )
+
                 expr_attr_names = {
                     f"#{key_alias(k)}": k for k in data.keys() if k != "user_id"
                 }
                 expr_attr_values = {
-                    f":{key_alias(k)}": v for k, v in data.items() if k != "user_id"
+                    f":{key_alias(k)}": v
+                    for k, v in data.items()
+                    if k != "user_id" and k not in attrs_to_delete
                 }
 
                 table.update_item(

--- a/tests/test_AwsUser.py
+++ b/tests/test_AwsUser.py
@@ -422,7 +422,7 @@ def test_save_existing_empty_data(monkeypatch):
     mock_table.update_item.return_value = {
         "ExpressionAttributeValues": {"updated_at": "2024-06-01T12:00:00Z"}
     }
-    user._create_non_null_dynamodb_dict = MagicMock(return_value={})
+    user._get_values_as_dict = MagicMock(return_value={})
     monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
     with patch(
         "pycommon.dal.providers.aws.AwsUser.nowstr", return_value="2024-06-01T12:00:00Z"
@@ -446,6 +446,72 @@ def test_save_raises_mapped_exception(monkeypatch):
     ):
         with pytest.raises(RuntimeError, match="mapped error"):
             user.save()
+
+
+def test_deletes_attributes_set_to_none(monkeypatch):
+    user = make_user()
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {
+            "user_id": "u1",
+            "email": "test@example.com",
+            "family_name": "Smith",
+            "given_name": "John",
+            "custom:saml_groups": '["abc"]',
+            "custom:vu_groups": None,
+            "updated_at": None,
+            "version": 1,
+        }
+    }
+    monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
+    user.cust_saml_groups = None  # This should trigger deletion
+    with patch("pycommon.dal.providers.aws.AwsUser.nowstr", return_value="now"):
+        user.save()
+        args, kwargs = mock_table.update_item.call_args
+        assert "REMOVE #custom_saml_groups" in kwargs["UpdateExpression"]
+
+
+def test_save_no_changes(monkeypatch):
+    user = make_user()
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {
+            "user_id": "u1",
+            "email": "test@example.com",
+            "family_name": "Smith",
+            "given_name": "John",
+            "version": 1,
+            "updated_at": "now",
+        }
+    }
+    monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
+    user.email = "test@example.com"
+    with patch("pycommon.dal.providers.aws.AwsUser.nowstr", return_value="now"):
+        user.save()
+        assert not mock_table.update_item.called
+
+
+def test_none_deletes_attr(monkeypatch):
+    user = make_user()
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        "Item": {
+            "user_id": "u1",
+            "email": "test@example.com",
+            "family_name": "Smith",
+            "given_name": "John",
+            "custom:saml_groups": '["abc"]',
+            "custom:vu_groups": None,
+            "updated_at": None,
+            "version": 1,
+        }
+    }
+    monkeypatch.setattr(AwsUser, "_user_table", classmethod(lambda cls: mock_table))
+    user.cust_saml_groups = None  # This should trigger deletion
+    with patch("pycommon.dal.providers.aws.AwsUser.nowstr", return_value="now"):
+        user.save()
+        args, kwargs = mock_table.update_item.call_args
+        assert "REMOVE #custom_saml_groups" in kwargs["UpdateExpression"]
 
 
 def test_get_version_default():


### PR DESCRIPTION
If a User object has one of its attributes set to None, and that attribute is NOT NONE upstream, then this change will ensure that the attribute is removed from the record. For example, if a record has cust_saml_groups = ["ABC"] and we run the following code:
```python
user = AwsUser(...)
user.cust_saml_groups = None
user.save()
```
The attribute will be removed in the DynamoDB record.