### PR TITLE
Add AwsAdminConfig set_config

### DIFF
--- a/pycommon/dal/providers/aws/AwsAdminConfig.py
+++ b/pycommon/dal/providers/aws/AwsAdminConfig.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Dict, Optional
 
 from pycommon.dal.contracts import AdminConfigABC
 from pycommon.dal.providers.aws import AwsProvider
-from pycommon.dal.providers.aws.helpers import map_aws_error
+from pycommon.dal.providers.aws.helpers import map_aws_error, nowstr
 
 
 class AwsAdminConfig(AdminConfigABC):
@@ -46,9 +46,21 @@ class AwsAdminConfig(AdminConfigABC):
         except Exception as e:
             raise map_aws_error(e)
 
-    def set_config(self, key: str, value: Any) -> bool:
-        """Set (overwrite) a configuration value by key."""
-        raise NotImplementedError("set_config is not implemented yet")
+    @classmethod
+    def set_config(cls, key: str, value: Any) -> None:
+        """Set (overwrite) a configuration value by key.
+
+        The key is the config_id in the DynamoDB table. The value is stored
+        in the 'data' field of the record. The 'last_updated' field is set to
+        the current time in ISO format.
+        """
+        try:
+            table = cls._table()
+            table.put_item(
+                Item={"config_id": key, "data": value, "last_updated": nowstr()}
+            )
+        except Exception as e:
+            raise map_aws_error(e)
 
     def delete_config(self, key: str) -> bool:
         """Delete a configuration value by key."""

--- a/tests/test_AwsAdminConfig.py
+++ b/tests/test_AwsAdminConfig.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pycommon.dal.providers.aws import AwsAdminConfig
+from pycommon.dal.providers.aws.helpers import nowstr
 
 
 def test_get_config_returns_value(monkeypatch):
@@ -86,3 +87,28 @@ def test_list_with_cursor(monkeypatch):
     keys, cursor = AwsAdminConfig.list(cursor="foo")
     assert keys == ["foo", "bar"]
     assert cursor == {"config_id": "bar"}
+
+
+def test_set_config(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    AwsAdminConfig.set_config("test_key", {"some": "value"})
+    dummy_table.put_item.assert_called_once_with(
+        Item={
+            "config_id": "test_key",
+            "data": {"some": "value"},
+            "last_updated": nowstr(),
+        }
+    )
+
+
+def test_set_config_raises_exception(monkeypatch):
+    dummy_provider = MagicMock()
+    dummy_table = MagicMock()
+    dummy_provider.get_table.return_value = dummy_table
+    monkeypatch.setattr(AwsAdminConfig, "provider", dummy_provider)
+    dummy_table.put_item.side_effect = Exception("Dynamo error")
+    with pytest.raises(Exception, match="Dynamo error"):
+        AwsAdminConfig.set_config("test_key", {"some": "value"})


### PR DESCRIPTION
This adds a _very_ basic set_config implementation that writes the configuration back to the data field in the Admin Config table. This is enough to get us to the point in which we can implement the JIT user provisioning as it exists in the sync script.